### PR TITLE
Add preset mode support for Breez Max

### DIFF
--- a/custom_components/cielo_home/const.py
+++ b/custom_components/cielo_home/const.py
@@ -46,3 +46,5 @@ FAN_FANSPEED_VALUE = "fanspeed"
 
 FOLLOW_ME_ON = "on"
 FOLLOW_ME_OFF = "off"
+
+DEVICE_BREEZ_MAX = "BREEZ-MAX"

--- a/custom_components/cielo_home/select.py
+++ b/custom_components/cielo_home/select.py
@@ -6,7 +6,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .cielohomedevice import CieloHomeDevice
-from .const import DOMAIN
+from .const import (
+    DEVICE_BREEZ_MAX,
+    DOMAIN
+)
 from .entity import CieloHomeEntity
 
 
@@ -102,10 +105,13 @@ class CieloHomePresetSelect(CieloHomeEntity, SelectEntity):
     def _update_internal_state(self):
         """None."""
         self._attr_current_option = self._device.get_preset_mode()
-        self._attr_available = self._device.get_status() and (
-            self._device.get_hvac_mode() == HVACMode.HEAT
-            or self._device.get_hvac_mode() == HVACMode.COOL
-        )
+        if self._device.get_device_type() == DEVICE_BREEZ_MAX:
+            self._attr_available = self._device.get_status()
+        else:
+            self._attr_available = self._device.get_status() and (
+                self._device.get_hvac_mode() == HVACMode.HEAT
+                or self._device.get_hvac_mode() == HVACMode.COOL
+            )
 
     def select_option(self, option: str) -> None:
         """Change the selected option."""


### PR DESCRIPTION
This should address issue #64

Hi @bodyscape, this change enables preset selection with Breez Max, but honestly I'm not very proud of the code, it feels hack-ish with all the `if BREEZE_MAX`, depending on how different these devices work at the API level, it may be worth to refactor cielohomedevice in specialized classes. 

Please, let me know if this patch is acceptable as it is otherwise provide me some guidance on how you would prefer the "logic fork" to be implemented.

Please, keep in mind I only tested it on a Breez Max, as that's the only device I have access too