### PR TITLE
Fix Turbo mode for MRCOOL BI04 devices

### DIFF
--- a/custom_components/cielo_home/cielohomedevice.py
+++ b/custom_components/cielo_home/cielohomedevice.py
@@ -184,7 +184,7 @@ class CieloHomeDevice:
         action["turbo"] = value
         self._device["latestAction"]["turbo"] = value
 
-        if self.get_device_type_version() != "BI03":
+        if self.get_device_type_version() != "BI03" or self.get_device_type_version() != "BI04":
             value = "on/off"
 
         self._send_msg(action, "turbo", value)


### PR DESCRIPTION
Ref issue: #63

Most recent version 1.7.7 accommodates fix for Turbo mode on MRCOOL devices, but only the old device type, `BI03`. This PR also supports new device type `BI04`.

New device type, for example MRCOOL DIY Series Outtasight Ceiling Cassette (Model: DIYCASSETTE**HP-230C25) are labeled as device type `BI04`

This fix has been confirmed working for several users.