### PR TITLE
feat: temperature offset calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add temperature offset calibration as a Number entity per supporting device, plus a `cielo_home.set_temperature_offset` service on climate entities. Per-call magnitude is capped at 8 by the protocol, so reaching the extremes of the ±15 range may require multiple calls.
+
 ## 1.0.0
 
 - First version support for Cielo Home

--- a/custom_components/cielo_home/cielohome.py
+++ b/custom_components/cielo_home/cielohome.py
@@ -276,6 +276,8 @@ class CieloHome:
                                         js_data["message_type"] == "StateUpdate"
                                         or js_data["message_type"]
                                         == "DeviceSettingsAck"
+                                        or js_data["message_type"]
+                                        == "CalibrationAck"
                                     ):
                                         for listener in self.__event_listener:
                                             listener.data_receive(js_data)

--- a/custom_components/cielo_home/cielohomedevice.py
+++ b/custom_components/cielo_home/cielohomedevice.py
@@ -252,6 +252,16 @@ class CieloHomeDevice:
         msg["actionString"] = action_string
         self._api.send_action(msg)
 
+    def _send_msg_calibration(self, action_string) -> None:
+        """None."""
+        # Calibration frames use snake_case mac_address and action_string,
+        # unlike the camelCase used by actionControl/deviceSettings frames.
+        msg = self._get_base_msg("calibration")
+        msg["mac_address"] = msg.pop("macAddress")
+        msg["action_string"] = action_string
+        msg["mid"] = "WEB"
+        self._api.send_action(msg)
+
     def _send_msg(
         self,
         action,

--- a/custom_components/cielo_home/cielohomedevice.py
+++ b/custom_components/cielo_home/cielohomedevice.py
@@ -479,14 +479,9 @@ class CieloHomeDevice:
         if delta == 0:
             return
 
-        # Calibration protocol caps single-frame magnitude at 8; longer
-        # traversals require a follow-up call from the user.
-        magnitude = abs(delta)
-        if magnitude > 8:
-            magnitude = 8
-
+        magnitude = min(abs(delta), 8)
         sign_digit = "1" if delta > 0 else "2"
-        self._send_msg_calibration("JTSC:" + sign_digit + str(magnitude))
+        self._send_msg_calibration(f"JTSC:{sign_digit}{magnitude}")
 
     def get_current_temperature(self) -> float:
         """None."""

--- a/custom_components/cielo_home/cielohomedevice.py
+++ b/custom_components/cielo_home/cielohomedevice.py
@@ -465,6 +465,29 @@ class CieloHomeDevice:
         """None."""
         self.send_temperature(int(self._device["latestAction"]["temp"]) - 1)
 
+    def send_temperature_offset(self, value: int) -> None:
+        """None."""
+        current = self.get_temperature_offset()
+        if current is None:
+            _LOGGER.warning(
+                "Cannot set temperature offset on %s: current offset unknown",
+                self.get_name(),
+            )
+            return
+
+        delta = int(value) - current
+        if delta == 0:
+            return
+
+        # Calibration protocol caps single-frame magnitude at 8; longer
+        # traversals require a follow-up call from the user.
+        magnitude = abs(delta)
+        if magnitude > 8:
+            magnitude = 8
+
+        sign_digit = "1" if delta > 0 else "2"
+        self._send_msg_calibration("JTSC:" + sign_digit + str(magnitude))
+
     def get_current_temperature(self) -> float:
         """None."""
         try:
@@ -715,6 +738,12 @@ class CieloHomeDevice:
     def get_target_temperature(self) -> float:
         """None."""
         return float(self._device["latestAction"]["temp"])
+
+    def get_temperature_offset(self) -> int | None:
+        """None."""
+        with contextlib.suppress(KeyError, TypeError, ValueError):
+            return int(self._device["tempCalibrationOffset"])
+        return None
 
     def get_turbo(self) -> str:
         """None."""
@@ -1111,6 +1140,12 @@ class CieloHomeDevice:
                         self._device["deviceSettings"]["screenDisplayValue"] = "0"
 
                     self._device["deviceSettings"]["brightnessValue"] = data["H2"]
+
+            with contextlib.suppress(KeyError):
+                if data["message_type"] == "CalibrationAck":
+                    self._device["tempCalibrationOffset"] = data[
+                        "temp_calibration_offset"
+                    ]
 
             self.dispatch_state_timer()
             # self.dispatch_state_updated()

--- a/custom_components/cielo_home/climate.py
+++ b/custom_components/cielo_home/climate.py
@@ -82,6 +82,16 @@ async def async_setup_entry(
         "async_sync_ac_state",
     )
 
+    platform.async_register_entity_service(
+        "set_temperature_offset",
+        {
+            vol.Required("offset"): vol.All(
+                vol.Coerce(int), vol.Range(min=-15, max=15)
+            ),
+        },
+        "async_set_temperature_offset",
+    )
+
 
 class CieloHomeThermostat(CieloHomeEntity, ClimateEntity):
     """Representation of a Cielo Home thermostat."""
@@ -167,6 +177,10 @@ class CieloHomeThermostat(CieloHomeEntity, ClimateEntity):
     ) -> None:
         """Sync_ac_state."""
         self._device.sync_ac_state(power, temp, mode, fan_speed, swing, preset)
+
+    async def async_set_temperature_offset(self, offset: int) -> None:
+        """Set the temperature calibration offset."""
+        self._device.send_temperature_offset(offset)
 
     def set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""

--- a/custom_components/cielo_home/number.py
+++ b/custom_components/cielo_home/number.py
@@ -29,6 +29,10 @@ async def async_setup_entry(
             entity = CieloHomeBacklightBrightness(device)
             entities.append(entity)
 
+        if device.get_temperature_offset() is not None:
+            entity = CieloHomeTemperatureOffsetNumber(device)
+            entities.append(entity)
+
     async_add_entities(entities)
 
 
@@ -100,3 +104,32 @@ class CieloHomeBacklightBrightness(CieloHomeEntity, NumberEntity):
     def set_native_value(self, value: float) -> None:
         """Set new value."""
         self._device.send_screenbacklightBrightness(int(value))
+
+
+class CieloHomeTemperatureOffsetNumber(CieloHomeEntity, NumberEntity):
+    """None."""
+
+    def __init__(self, device: CieloHomeDevice) -> None:
+        """None."""
+        super().__init__(
+            device,
+            device.get_name() + " " + "Temperature Offset",
+            device.get_uniqueid() + "_temperature_offset",
+        )
+        self._attr_icon = "mdi:plus-minus-variant"
+        # No device_class: this is a temperature delta, not an absolute reading.
+        self._attr_mode: NumberMode = NumberMode.SLIDER
+        self._attr_native_unit_of_measurement = self._device.get_unit_of_temperature()
+        self._attr_native_step = 1
+        self._attr_native_min_value = -15
+        self._attr_native_max_value = 15
+        self._device.add_listener(self)
+        self._update_internal_state()
+
+    def _update_internal_state(self):
+        """None."""
+        self._attr_native_value = self._device.get_temperature_offset()
+
+    def set_native_value(self, value: float) -> None:
+        """Set new value."""
+        self._device.send_temperature_offset(int(value))

--- a/custom_components/cielo_home/number.py
+++ b/custom_components/cielo_home/number.py
@@ -117,7 +117,6 @@ class CieloHomeTemperatureOffsetNumber(CieloHomeEntity, NumberEntity):
             device.get_uniqueid() + "_temperature_offset",
         )
         self._attr_icon = "mdi:plus-minus-variant"
-        # No device_class: this is a temperature delta, not an absolute reading.
         self._attr_mode: NumberMode = NumberMode.SLIDER
         self._attr_native_unit_of_measurement = self._device.get_unit_of_temperature()
         self._attr_native_step = 1

--- a/custom_components/cielo_home/services.yaml
+++ b/custom_components/cielo_home/services.yaml
@@ -135,3 +135,32 @@ sync_ac_state:
           options:
             - "none"
             - "Turbo"
+
+# Service ID
+set_temperature_offset:
+  # Service name as shown in UI
+  name: Set Temperature Offset
+  # Description of the service
+  description: Set the temperature calibration offset (delta) applied to the device's room temperature reading. Per-call magnitude is capped at 8 by the protocol; reaching the extremes of the supported range may require multiple calls.
+  # If the service accepts entity IDs, target allows the user to specify entities by entity, device, or area.
+  target:
+  # Different fields that your service accepts
+  fields:
+    # Key of the field
+    offset:
+      # Field name as shown in UI
+      name: Offset
+      # Description of the field
+      description: Calibration offset to apply, in the device's temperature unit.
+      # Whether or not field is required (default = false)
+      required: true
+      # Example value that can be passed for this field
+      example: 2
+      # The default field value
+      default: 0
+      # Selector to control the input UI for this field
+      selector:
+        number:
+          min: -15
+          max: 15
+          step: 1


### PR DESCRIPTION
## What

Adds a per-device temperature offset calibration entity (and matching service) to mirror the offset slider in the Cielo web UI.

Closes #106.

✅ Tested in HA
<img width="566" height="797" alt="image" src="https://github.com/user-attachments/assets/c9cd669f-ac20-4c30-9fd3-3b492dc5e60d" />


## Why

The Cielo web UI exposes a per-device temperature offset — a signed delta added to the reported room temperature, useful for correcting an inaccurate sensor. The HA integration didn't surface this control, so the only way to compensate from HA was to swap in separate Bluetooth thermometer hardware. This adds the existing functionality to HA.

## API evidence

Captured against `home.cielowigle.com` on a BREEZ-I (BI04) on firmware `2.6.0`.

**Outbound** (HA → Cielo) — `calibration` action. Note the snake_case `mac_address` and `action_string` keys (a third envelope shape, distinct from `actionControl` and `remote`):

```json
{
  "action": "calibration",
  "mac_address": "<MAC>",
  "action_string": "JTSC:NN",
  "actionSource": "WEB",
  "user_id": "<uid>",
  "fw_version": "2.6.0,2.6.0",
  "deviceTypeVersion": "BI04",
  "mid": "WEB",
  "connection_source": 1,
  "application_version": "1.4.7",
  "ts": 1777438898
}
```

`JTSC:NN` is a signed two-digit relative delta: tens digit is sign (`1` = +, `2` = −), ones digit is magnitude (`0–9`). Web UI clamps per-frame magnitude to `8`. Examples observed: `JTSC:12` → +2, `JTSC:14` → +4, `JTSC:22` → −2, `JTSC:27` → −7.

**Inbound** (`CalibrationAck`):

```json
{
  "message_type": "CalibrationAck",
  "mac_address": "<MAC>",
  "temp_calibration_offset": "-1",
  "lat_env_var": {"temperature": "71", "humidity": "0"},
  "device_status": 1,
  "device_name": "Primary",
  "fw_version": "2.6.0,2.6.0",
  "MID": "WEB"
}
```

**REST device-list** carries the current offset at the device top level as `tempCalibrationOffset` (signed integer string), so the entity has its initial value at HA startup.

## How it's surfaced

- **Number entity per supporting device:** `number.<device>_temperature_offset`. Slider, min/max `±15`, step `1`, unit matches device temperature unit, no `device_class` (it's a delta, not an absolute).
- **Service on climate platform:** `cielo_home.set_temperature_offset` with an `offset` field validated to `±15`. Mirrors the existing `sync_ac_state` registration in `climate.py`.
- **Capability probe:** entity is created only when `tempCalibrationOffset` is present in the REST payload — older units that omit the field don't get the entity.
- **Long-traversal handling:** for HA targets requiring `|delta| > 8`, sends a single clamped frame (the protocol max). The slider settles at the intermediate value; user drags again to finish a long traversal. Simpler than chained-send state machine; rare in practice given the ±15 bound.

<!-- TODO: drop a screenshot of one of the offset entities in HA here. -->

## Hardware tested

Verified on 4× BREEZ-I (BI04) on firmware `2.6.0,2.6.0`:

- Primary, Living Room, Nursery (online; entity active)
- Renner (offline at test time; entity correctly shows `unavailable`)

## Test plan

- [x] **HA → Cielo:** `number.set_value` from `-6` → `-4`. Outbound `JTSC:12` confirmed in WS log; `CalibrationAck` returned `temp_calibration_offset: "-4"` ~1s later; entity updated.
- [x] **Cielo → HA:** offset changed to `-2` from the Cielo web UI; unsolicited `CalibrationAck` arrived; HA entity reflected new value within ~1s.
- [x] **Magnitude-1 deltas** (`JTSC:11` and `JTSC:21`) — accepted by the device. (These weren't in the original DevTools captures since the web UI's slider buttons step by 2 visually, but the protocol accepts them; verified `step=1` in the entity is correct.)
- [x] **Long-traversal clamp:** target `+12` from `-6` (delta `+18`) → outbound `JTSC:18` (clamped to +8) → device lands at `+2`. Slider settles correctly; second drag to `+12` would close the gap.
- [x] **Service call:** `cielo_home.set_temperature_offset` with `offset: -6` against `climate.primary` — outbound `JTSC:22`, ack returned `-6`, entity reflected.
- [x] **Zero-delta no-op:** setting the entity to its current value does not emit a calibration frame.
- [x] **Restart persistence:** after `ha core restart`, all four entities restored to their actual current offsets from REST (no `unknown`, no default 0).
- [x] **Graceful absence on unsupported devices:** capability probe gates entity creation; the offline Renner device still got the entity (since REST exposes the field) but reports `unavailable` until the device comes back, no errors logged.
- [x] **Debug logs clean** during all of the above — no warnings, exceptions, or tracebacks from `custom_components.cielo_home`.

## Out of scope

- **`manifest.json` version bump** — your call.
- **Humidity offset.** REST exposes `humCalibrationOffset` and `isHumCalibrationSync` on every device, but I haven't captured a humidity write frame (no humidity-sensing device in my test setup). Happy to add as a follow-up if a humidity-equipped user contributes a captured calibration write.
- **Config-flow changes:** none.
- **Existing setter / climate-entity refactoring:** none — the patch is purely additive.
- **Tests:** the repo has no test harness today; not introducing one for this PR.
- **New dependencies:** none.

## Commits

1. `feat(api): handle CalibrationAck and add calibration sender helper` — extends WS dispatcher and adds `_send_msg_calibration`.
2. `feat(device): expose temperature offset on device model` — `get_temperature_offset`, `send_temperature_offset`, `CalibrationAck` branch in `data_receive`.
3. `feat(number): add temperature offset Number entity per device`.
4. `feat(service): set_temperature_offset service on climate platform` — service registration + `services.yaml` entry.
5. `docs: changelog entry for temperature offset support`.
6. `refactor: collapse offset clamp and drop narrative comments` — minor cleanup post-review.

Happy to revise the shape if you'd prefer something different (service-only, different bounds, naming changes, etc.) — just let me know.
