### PR TITLE
Add reauth + reconfigure so expired tokens can recover (fixes #109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/custom_components/cielo_home/__init__.py
+++ b/custom_components/cielo_home/__init__.py
@@ -8,6 +8,7 @@ from types import MappingProxyType, MethodType  # noqa: F401
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from .cielohome import CieloHome
 from .cielohomedevice import CieloHomeDevice
@@ -43,7 +44,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data["user_id"],
         entry.data["x_api_key"],
     ):
-        _LOGGER.error("Failed to login to Cielo Home")
+        # Stored token could not be refreshed (expired/revoked). Trigger the
+        # re-auth flow so the user can log in again instead of silently ending
+        # up with all entities unavailable (see issue #109).
+        raise ConfigEntryAuthFailed(
+            "Cielo Home token refresh failed; please re-authenticate"
+        )
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = api

--- a/custom_components/cielo_home/cielohome.py
+++ b/custom_components/cielo_home/cielohome.py
@@ -111,12 +111,14 @@ class CieloHome:
         self._last_refresh_token_ts = self.get_ts()
         self._token_expire_in_ts = self.get_ts() + TIME_REFRESH_TOKEN
 
-        await self.async_refresh_token(test=True)
+        authenticated = await self.async_refresh_token(test=True)
 
-        if self._access_token != "":
+        # Only open the websocket when the token is actually valid; starting it
+        # with a dead token just produces a wss 403 (see issue #109).
+        if authenticated and self._access_token != "":
             self.create_websocket_log_exception(False)
 
-        return True
+        return authenticated
 
     async def async_refresh_token(
         self,

--- a/custom_components/cielo_home/config_flow.py
+++ b/custom_components/cielo_home/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -29,6 +30,15 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required("password"): str,
         vol.Optional("force_connection_source", default=False): bool,
         vol.Optional("connection_source", default=False): bool,
+    }
+)
+
+# Re-auth only needs the credentials; the connection-source toggles are kept
+# from the existing entry.
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("username"): str,
+        vol.Required("password"): str,
     }
 )
 
@@ -101,6 +111,80 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication when the stored token can no longer refresh."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm re-authentication with email + password."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                entry = self._get_reauth_entry()
+                # Keep the user's existing connection-source toggles.
+                data = {
+                    **info["data"],
+                    "force_connection_source": entry.data.get(
+                        "force_connection_source", False
+                    ),
+                    "connection_source": entry.data.get("connection_source", False),
+                }
+                return self.async_update_reload_and_abort(entry, data=data)
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Re-authenticate on demand from the entry's menu (no delete needed)."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(entry, data=info["data"])
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                {
+                    "force_connection_source": entry.data.get(
+                        "force_connection_source", False
+                    ),
+                    "connection_source": entry.data.get("connection_source", False),
+                },
+            ),
+            errors=errors,
         )
 
 

--- a/custom_components/cielo_home/strings.json
+++ b/custom_components/cielo_home/strings.json
@@ -2,12 +2,28 @@
   "config": {
     "step": {
       "user": {
+        "description": "Log in with your Cielo Home account.",
         "data": {
-          "access_token": "[%key:common::config_flow::data::access_token%]",
-          "refresh_token": "refresh_token",
-          "session_id": "session_id",
-          "user_id": "user_id",
-          "x_api_key": "x_api_key",
+          "username": "Email",
+          "password": "[%key:common::config_flow::data::password%]",
+          "force_connection_source": "force_connection_source",
+          "connection_source": "connection_source"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Cielo Home",
+        "description": "The stored token has expired. Enter your Cielo Home email and password to sign in again.",
+        "data": {
+          "username": "Email",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Cielo Home",
+        "description": "Enter your Cielo Home email and password to refresh the connection without removing the integration.",
+        "data": {
+          "username": "Email",
+          "password": "[%key:common::config_flow::data::password%]",
           "force_connection_source": "force_connection_source",
           "connection_source": "connection_source"
         }
@@ -19,7 +35,9 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }
 }

--- a/custom_components/cielo_home/translations/en.json
+++ b/custom_components/cielo_home/translations/en.json
@@ -1,7 +1,9 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Re-configuration was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -10,11 +12,28 @@
         },
         "step": {
             "user": {
+                "description": "Log in with your Cielo Home account.",
                 "data": {
-                    "access_token": "Access Token (accessToken)",
-                    "refresh_token": "Refresh Token (refreshToken)",
-                    "session_id": "Session Id (sessionId)",
-                    "user_id": "User Id (userId)",
+                    "username": "Email",
+                    "password": "Password",
+                    "force_connection_source": "Force connection source value (False by default)",
+                    "connection_source": "Connection source value (True or False)"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate Cielo Home",
+                "description": "The stored token has expired. Enter your Cielo Home email and password to sign in again.",
+                "data": {
+                    "username": "Email",
+                    "password": "Password"
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Cielo Home",
+                "description": "Enter your Cielo Home email and password to refresh the connection without removing the integration.",
+                "data": {
+                    "username": "Email",
+                    "password": "Password",
                     "force_connection_source": "Force connection source value (False by default)",
                     "connection_source": "Connection source value (True or False)"
                 }


### PR DESCRIPTION
## Problem

When the stored token can no longer be refreshed, the integration goes into a dead-end:

```
ERROR ... Call refreshToken error 401
WARNING ... HTTP 498: {"error":{"code":498,"message":"invalid or expired token"}}
ERROR ... 403 ... url='wss://apiwss.smartcielo.com/websocket/?sessionId=...'
```

`async_setup_entry` only logs *"Failed to login to Cielo Home"* and keeps going, so **every entity becomes unavailable** and a reload/restart does not recover — the only fix is deleting and re-adding the integration. This is exactly what's reported in #109.

#110 added email/password login, but only on the **initial add step** (`async_step_user`). An existing entry whose token has died has no path back to that login form — there is no reauth or reconfigure step — so users are stuck.

## Fix

Wire up the standard Home Assistant re-auth path and add an on-demand reconfigure step. Builds directly on #110 (same `async_login` / token bundle).

- **`__init__.py`** — raise `ConfigEntryAuthFailed` when the token refresh fails at setup, so HA surfaces a **"reconfigure to fix"** prompt instead of silent unavailability.
- **`cielohome.py`** — `async_auth` now returns the real refresh result and only opens the websocket when the token is actually valid (avoids the `wss 403` on a dead token seen in #109).
- **`config_flow.py`** — add:
  - `async_step_reauth` / `async_step_reauth_confirm` — auto-triggered by the exception above; asks for email + password.
  - `async_step_reconfigure` — a **Reconfigure** menu item on the entry so users can re-authenticate any time without deleting.
  - Both log in via email/password and update the **existing** entry in place with `async_update_reload_and_abort`, preserving the `force_connection_source` / `connection_source` toggles. Same `entry_id`, devices and entities kept — no delete.
- **`strings.json` / `translations/en.json`** — fix the stale token-field labels still on the `user` step (leftover from before #110) and add `reauth_confirm` + `reconfigure` step text and the success messages.

## Result

- Expired token → HA shows a re-auth notification → enter email/password → back online, no delete.
- A **Reconfigure** option is always available on the entry for proactive re-login.

## Testing

- Verified against a live account (5 devices): after the token expired (`/web/devices` → `498`), re-auth via email/password refreshed the tokens in place and `/web/devices` returned `200` with all devices — same entry, same entity IDs, automations intact.
- New flow steps validated against the current config-entries API (`_get_reauth_entry` / `_get_reconfigure_entry` / `async_update_reload_and_abort`); pattern mirrors core integrations (e.g. `bring`). `_abort_if_unique_id_mismatch()` is intentionally omitted since this integration does not set a `unique_id`.
- Line endings kept as CRLF to match the repo.

Fixes #109.
