### PR TITLE
fix: use /user/token/refresh + exponential websocket reconnect backoff

### DIFF
--- a/custom_components/cielo_home/cielohome.py
+++ b/custom_components/cielo_home/cielohome.py
@@ -157,18 +157,25 @@ class CieloHome:
                 self._user_id = user_id
                 self._last_x_api_key = x_api_key
 
-            headers: dict[str, str] = self._headers
-            headers["authorization"] = self._access_token
-            headers["x-api-key"] = self._last_x_api_key
+            # The legacy /web/token/refresh endpoint now returns 403
+            # ForbiddenException at the CloudFront edge for every caller
+            # (valid tokens included). The current mobile app refreshes via
+            # /user/token/refresh using the iOS app key, so we use that here.
+            headers: dict[str, str] = {
+                "accept": "*/*",
+                "content-type": "application/json",
+                "x-api-key": IOS_X_API_KEY,
+                "user-agent": IOS_USER_AGENT,
+                "authorization": self._access_token,
+            }
 
             data = {
-                "local": "en",
                 "refreshToken": self._refresh_token,
             }
             async with ClientSession() as session:  # noqa: SIM117
                 async with session.post(
-                    "https://" + URL_API + "/web/token/refresh",
-                    headers=self._headers,
+                    "https://" + URL_API + "/user/token/refresh",
+                    headers=headers,
                     json=data,
                 ) as response:
                     if response.status == 200:


### PR DESCRIPTION
Two related fixes for the "Cielo devices go offline and won't recover" failure.

## 1. Token refresh hits a dead endpoint (403)

Periodic token refresh is broken. The integration authenticates and loads
devices fine on startup, but every refresh cycle fails, and once the access
token expires the connection dies. Re-authenticating does **not** help.

Root cause: `/web/token/refresh` now returns `403 ForbiddenException` at the
CloudFront/API-Gateway edge for **every** caller — including a
currently-valid access token + correct web `x-api-key`. The block is at the
edge, before the request reaches the application.

```
GET  /web/devices          (web key + valid token) -> 200 SUCCESS   (token is valid)
POST /web/token/refresh     (web key + valid token) -> 403 ForbiddenException
POST /web/token/refresh     (freshly-minted token)  -> 403 ForbiddenException
```

The current mobile app refreshes via `POST /user/token/refresh` using the
iOS app key. Switch `async_refresh_token()` to that endpoint (iOS
`x-api-key` + user-agent, both already in `const.py` from #113). Response
shape is identical, so downstream parsing is unchanged.

```
POST /user/token/refresh    (iOS key + valid token) -> 200 SUCCESS   (rotated tokens)
```

## 2. Websocket reconnect storm self-inflicts a 429

Even with auth fixed, devices stay offline: the WSS endpoint
(`apiwss.smartcielo.com/websocket/`) rate-limits with **HTTP 429** on rapid
reconnects from the same IP.

```
WSS handshake (valid token)   -> 429 Too Many Requests
WSS handshake (no token)      -> 429   (pure IP-level throttle)
```

The reconnect loop used a **fixed 10s delay** (0s on the `_reconnect_now`
fast path), so a rejected handshake retried every 10s forever — keeping the
IP throttled and the connection permanently offline even though auth and
refresh succeed. The mobile app holds a single connection and is unaffected.

Add exponential backoff on the failed-handshake path: 10s → 20s → 40s …
capped at 5 min (`RECONNECT_BACKOFF_MAX`). The attempt counter resets to 0
on a genuine `Connected success`, so a normal transient drop still
reconnects promptly. This lets the IP-level throttle clear instead of being
continuously refreshed by the storm.

## Notes

- Both changes are confined to `cielohome.py`.
- The refresh change builds a local headers dict instead of mutating
  `self._headers`; every other caller sets `authorization`/`x-api-key` on it
  immediately before use, so removing that side effect is safe.
- The `"local": "en"` refresh body field is dropped — the mobile endpoint
  does not require it (verified with and without).

## Testing

Verified live against the production API: `/web/token/refresh` 403s for
valid/fresh/stale tokens while `/user/token/refresh` returns 200 with
rotated tokens; the WSS 429 is IP-level (bare handshake also 429s). Patched
module compiles and the simulated refresh call succeeds end-to-end.
