### PR TITLE
fix: exponential backoff on websocket reconnect to avoid 429 storms

### DIFF
--- a/custom_components/cielo_home/cielohome.py
+++ b/custom_components/cielo_home/cielohome.py
@@ -33,6 +33,11 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 TIMEOUT_RECONNECT = 10
+# Exponential backoff bounds for repeated websocket-connect failures. The
+# WSS endpoint rate-limits (HTTP 429) on rapid reconnects from the same IP;
+# without backoff the integration reconnect-storms and the throttle never
+# clears. Backoff grows 10s -> 20s -> 40s ... capped at 5 min.
+RECONNECT_BACKOFF_MAX = 300
 TIME_REFRESH_TOKEN = 3300
 TIMER_PING = 540
 TIMER_PONG = 60
@@ -70,6 +75,7 @@ class CieloHome:
         self._last_connection_ts: int = 0
         self._last_x_api_key: str = None
         self._reconnect_now = False
+        self._reconnect_attempts: int = 0
         self.hass: HomeAssistant = hass
         self._entry: ConfigEntry = entry
         self._appliance_id = None
@@ -317,6 +323,9 @@ class CieloHome:
 
                     _LOGGER.info("Connected success")
                     self._last_connection_ts = self.get_ts()
+                    # A genuine handshake succeeded — clear the backoff so the
+                    # next transient drop reconnects promptly.
+                    self._reconnect_attempts = 0
                     self.stop_timer_connection_lost()
 
                     if update_state:
@@ -433,10 +442,21 @@ class CieloHome:
             #    listener.lost_connection()
             self.start_timer_connection_lost()
             if not self._reconnect_now:
-                _LOGGER.debug(
-                    "Try reconnection in " + str(TIMEOUT_RECONNECT) + " secondes"
+                # Connection failed to establish (or dropped immediately) —
+                # back off exponentially so repeated handshake rejections
+                # (e.g. HTTP 429 rate-limits) don't turn into a reconnect
+                # storm that keeps the endpoint throttled.
+                self._reconnect_attempts += 1
+                delay = min(
+                    TIMEOUT_RECONNECT * (2 ** (self._reconnect_attempts - 1)),
+                    RECONNECT_BACKOFF_MAX,
                 )
-                await asyncio.sleep(TIMEOUT_RECONNECT)
+                _LOGGER.debug(
+                    "Try reconnection in %s seconds (attempt %s)",
+                    delay,
+                    self._reconnect_attempts,
+                )
+                await asyncio.sleep(delay)
             else:
                 _LOGGER.debug("Reconnection")
             self._last_ts_ping = 0


### PR DESCRIPTION
## Problem

Even after #115 fixed token refresh, Cielo devices can stay offline and
never recover. The websocket endpoint
(`apiwss.smartcielo.com/websocket/`) rate-limits with **HTTP 429** on rapid
reconnects from the same IP:

```
WSS handshake (valid token) -> 429 Too Many Requests
WSS handshake (no token)    -> 429   (pure IP-level throttle, not auth)
```

The reconnect loop in `async_connect_wss()` uses a **fixed 10s delay** (and
0s on the `_reconnect_now` fast path). So a rejected handshake retries every
10s indefinitely, continuously refreshing the IP throttle — the connection
never recovers on its own even though auth and token refresh succeed. The
official mobile app holds a single long-lived connection and is unaffected.

## Fix

Add exponential backoff on the failed-handshake path:
10s → 20s → 40s → … capped at 5 min (`RECONNECT_BACKOFF_MAX`).

`_reconnect_attempts` resets to 0 on a genuine `Connected success`, so a
normal transient drop (which sets `_reconnect_now`) still reconnects
promptly — only repeated failures back off. This lets the IP-level throttle
clear instead of being kept alive by the storm.

## Notes

- Single-file change (`cielohome.py`).
- Only the failure path is throttled; the `_reconnect_now` fast-resume path
  after a successful connection is unchanged.

## Testing

Verified the 429 is IP-level (bare token-less handshake also 429s), so
backoff is the correct remedy. Patched module compiles; backoff sequence
10/20/40/80/160/300s confirmed by the `min(TIMEOUT_RECONNECT * 2**(n-1),
RECONNECT_BACKOFF_MAX)` formula.
