### PR TITLE
fix: don't reload integration on self-issued token writes (reload storm)

### DIFF
--- a/custom_components/cielo_home/__init__.py
+++ b/custom_components/cielo_home/__init__.py
@@ -92,11 +92,31 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
+# Entry-data keys the integration rewrites itself during normal operation
+# (token rotation). Changes limited to these must NOT trigger a reload,
+# otherwise every ~hourly (or, on WSS failure, every reconnect) token
+# refresh reloads the whole integration -- destroying the connection and
+# any reconnect backoff, producing a reload storm that keeps the WSS
+# endpoint rate-limited (HTTP 429) and the devices permanently offline.
+_TOKEN_KEYS = frozenset({"access_token", "refresh_token", "session_id"})
+
+
 async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
-    """Handle options update."""
+    """Handle entry update; skip reloads caused by our own token writes."""
 
     api: CieloHome = hass.data[DOMAIN][config_entry.entry_id]
-    if api.can_reload:
+
+    # Detect whether anything other than the self-managed token fields
+    # changed. Only a genuine config/options change should reload.
+    changed = {
+        k
+        for k in set(config_entry.data) | set(api.last_entry_data)
+        if config_entry.data.get(k) != api.last_entry_data.get(k)
+    }
+    api.last_entry_data = dict(config_entry.data)
+    non_token_change = bool(changed - _TOKEN_KEYS)
+
+    if api.can_reload and non_token_change:
         _LOGGER.info("Reload integration")
         hass.config_entries.async_schedule_reload(config_entry.entry_id)
     else:

--- a/custom_components/cielo_home/cielohome.py
+++ b/custom_components/cielo_home/cielohome.py
@@ -52,6 +52,9 @@ class CieloHome:
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Set up Cielo Home api."""
         self.can_reload: bool = True
+        # Snapshot of entry.data so update_listener can tell a genuine
+        # config change from our own token-rotation writes.
+        self.last_entry_data: dict = dict(entry.data) if entry is not None else {}
         self._is_running: bool = True
         self._stop_running: bool = False
         self._access_token: str = ""


### PR DESCRIPTION
## Problem

Cielo devices connect briefly, then go offline and never recover — the
integration silently reloads itself in a tight loop (~every 11s), which
keeps the websocket endpoint rate-limited (HTTP 429) and defeats the
reconnect backoff from #116.

Root cause: `update_listener` calls `async_schedule_reload()` whenever
`entry.data` changes. But the integration **rewrites `entry.data` itself**
on every token refresh (`async_refresh_token` → `async_update_entry`). So
each refresh tears down and rebuilds the entire `CieloHome` object.

- On the happy path this "only" reloads roughly hourly.
- When the websocket can't connect (e.g. the WSS endpoint returns 429),
  the reconnect loop refreshes the token every ~10s → writes `entry.data`
  → reloads the integration → brand-new object with a fresh backoff
  counter → immediate retry → **reload storm**.

The storm keeps the endpoint throttled and the devices permanently offline,
and it defeats the exponential reconnect backoff (#116) because the object
never lives long enough to back off. The existing single-shot `can_reload`
guard doesn't cover it, since multiple distinct token writes each re-arm it.

## Fix

Snapshot `entry.data` (`last_entry_data`) and only reload when a key **other
than** the self-managed token fields (`access_token`, `refresh_token`,
`session_id`) actually changes. Genuine config/options changes still
reload; token rotation no longer does.

## Notes

- Two-file change: `__init__.py` (the guard) and `cielohome.py` (init the
  `last_entry_data` snapshot).
- Complements #116 — with the storm stopped, the backoff can actually take
  effect and the 429 throttle clears.

## Testing

Confirmed on a live instance that `entry.data` (core.config_entries) was
being rewritten every ~11s while the WSS returned 429, i.e. a reload every
~11s. With this guard, token-refresh writes no longer trigger reloads.
Both modules compile.
