### PR TITLE
fix: KeyError 'followme' crashes switch platform (entities go unavailable)

### DIFF
--- a/custom_components/cielo_home/cielohomedevice.py
+++ b/custom_components/cielo_home/cielohomedevice.py
@@ -383,7 +383,7 @@ class CieloHomeDevice:
 
     def send_follow_me(self, value) -> None:
         """None."""
-        if self._device["latestAction"]["followme"] == value:
+        if self._device["latestAction"].get("followme") == value:
             return
 
         action = self._get_action()
@@ -716,8 +716,14 @@ class CieloHomeDevice:
         return self._device["latestAction"]["power"]
 
     def get_follow_me(self) -> str:
-        """None."""
-        return self._device["latestAction"]["followme"]
+        """Return the FollowMe state, defaulting to "off" when absent.
+
+        Some appliances advertise FollowMe support (appliance["followme"])
+        but do not include "followme" in latestAction until it is first
+        toggled. Reading it unguarded raised KeyError during switch setup,
+        crashing the switch platform and leaving all entities unavailable.
+        """
+        return self._device["latestAction"].get("followme", "off")
 
     def get_light(self) -> str:
         """None."""


### PR DESCRIPTION
## Problem

On 1.9.4, entities for some appliances load for a few seconds then go
unavailable. Reported in #117:

```
Error while setting up cielo_home platform for switch: 'followme'
Traceback (most recent call last):
  ...
  File ".../cielo_home/switch.py", line 155, in __init__
    self._attr_is_on = self.is_follow_me()
  File ".../cielo_home/switch.py", line 172, in is_follow_me
    return self._device.get_follow_me() == "on"
  File ".../cielo_home/cielohomedevice.py", line 720, in get_follow_me
    return self._device["latestAction"]["followme"]
KeyError: 'followme'
```

`get_is_followme_mode()` creates the Follow Me switch when the **appliance**
advertises FollowMe support (`appliance["followme"] != ""`). But
`get_follow_me()` reads **`latestAction["followme"]`**, which is not
necessarily present until FollowMe is first toggled. On such devices, switch
creation raises `KeyError` inside `async_setup_entry`, which crashes the
entire switch platform for that entry — so every entity ends up unavailable.

Confirmed on a live account: 5 appliances, **none** carry `followme` in
`latestAction` (keys: `temp`, `fanspeed`, `mode`, `swing`, `turbo`, …).

## Fix

Default `get_follow_me()` to `"off"` when the key is absent — consistent
with the boolean consumer (`get_follow_me() == "on"`) and with the
already-guarded `get_light()` / `_get_action()` reads a few lines away.
Also harden `send_follow_me()` with `.get()` so a user toggle before the
first reported state can't raise.

## Testing

Repro'd the `KeyError` against real device payloads lacking `followme`.
With the default, switch setup no longer raises and the switch initializes
as off (correct — FollowMe is inactive until toggled). Module compiles.

Refs #117.
