### PR TITLE
fix: websocket host moved to wss.smartcielo.com (apiwss now 403s) — fixes #109

### DIFF
--- a/custom_components/cielo_home/const.py
+++ b/custom_components/cielo_home/const.py
@@ -4,7 +4,7 @@ from homeassistant.components.climate import PRESET_NONE
 
 DOMAIN = "cielo_home"
 URL_API = "api.smartcielo.com"
-URL_API_WSS = "apiwss.smartcielo.com"
+URL_API_WSS = "wss.smartcielo.com"
 URL_CIELO = "https://home.cielowigle.com/"
 USER_AGENT = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
 


### PR DESCRIPTION
## The outage

Cielo moved their realtime websocket to a **new hostname**. The old host the
integration uses, `apiwss.smartcielo.com`, now returns **HTTP 403 Forbidden**
on the handshake for every caller. So the integration logs in fine and REST
works, but the websocket never opens → all entities go **unavailable**.

This is the mass "entities unavailable" outage in #109: control still works
from the Cielo app/website (they use the new host), REST `/web/devices`
returns 200, but the integration's live-state/control channel (websocket) is
dead.

## Root cause (confirmed live)

Captured the working web app (`home.cielowigle.com`) — it now connects to
**`wss://wss.smartcielo.com/websocket/`**, not `apiwss.…`. Verified with a
real account token, same sessionId + token, only the host differs:

```
apiwss.smartcielo.com  ->  HTTP 403 Forbidden
wss.smartcielo.com     ->  HTTP 101 Switching Protocols
```

After changing `URL_API_WSS`, the integration connects (`Connected success`)
and every online device reports live state again (verified on a 5-unit
account — the one offline unit correctly stays unavailable, deviceStatus 0).

## Fix

One line in `const.py`: point `URL_API_WSS` at `wss.smartcielo.com`.

Fixes #109.
